### PR TITLE
Add autoload class map to generated json

### DIFF
--- a/Classes/PackagesTYPO3ExtensionsGenerator.php
+++ b/Classes/PackagesTYPO3ExtensionsGenerator.php
@@ -104,6 +104,9 @@ class PackagesTYPO3ExtensionsGenerator {
 				'url' => 'http://typo3.org/extensions/repository/download/' . $extension['extensionkey'] . '/' . $version['version'] . '/t3x/',
 				'type' => 't3x',
 			),
+			'autoload' => array(
+				'classmap' => array('')
+			)
 		);
 
 		$packageArray = array_merge(


### PR DESCRIPTION
To simplify usage of composer class loading with TER extensions, add a class map of the extension to the generated json