### PR TITLE
[TASK] Use https instead of http for dist

### DIFF
--- a/src/Classes/PackagesTYPO3ExtensionsGenerator.php
+++ b/src/Classes/PackagesTYPO3ExtensionsGenerator.php
@@ -98,7 +98,7 @@ class PackagesTYPO3ExtensionsGenerator {
 				)
 			),
 			'dist' => array(
-				'url' => 'http://typo3.org/extensions/repository/download/' . $extension['extensionkey'] . '/' . $version['version'] . '/t3x/',
+				'url' => 'https://typo3.org/extensions/repository/download/' . $extension['extensionkey'] . '/' . $version['version'] . '/t3x/',
 				'type' => 't3x',
 			),
 			'replace' => array(


### PR DESCRIPTION
That's a naive patch to the dangling http / missing https / no redirecting case.

Closes: #16